### PR TITLE
fix logic initializing isError state

### DIFF
--- a/src/ReactFilterBox.tsx
+++ b/src/ReactFilterBox.tsx
@@ -40,6 +40,8 @@ export default class ReactFilterBox extends React.Component<any, any> {
             const expressions = this.parser.parse(props.query);
             if ((expressions as Expression[]).length > 0) {
                 errorState = validateQueryExpression(expressions as Expression[], autoCompleteHandler).isValid === false;
+            } else if ((expressions as ParsedError).isError) {
+                errorState = true;
             }
         }
 


### PR DESCRIPTION
if the filter expression failed to parse, it was still initializing isError to false